### PR TITLE
Fix compilation error in Python 2

### DIFF
--- a/pycosat.c
+++ b/pycosat.c
@@ -392,14 +392,15 @@ PyMODINIT_FUNC initpycosat(void)
 {
     PyObject *m;
 
+#ifdef IS_PY3K
     if (PyType_Ready(&SolIter_Type) < 0)
         return NULL;
-
-#ifdef IS_PY3K
     m = PyModule_Create(&moduledef);
     if (m == NULL)
         return NULL;
 #else
+    if (PyType_Ready(&SolIter_Type) < 0)
+        return;
     m = Py_InitModule3("pycosat", module_functions, module_doc);
     if (m == NULL)
         return;


### PR DESCRIPTION
Without this patch, I was getting the following error on Mac OS (Apple LLVM version 4.2 (clang-425.0.28) targeting x86_64-apple-darwin12.5.0):

```
pycosat.c:396:9 error: void function 'initpycosat' should not return a value
      [-Wreturn-type]
        return NULL;
        ^      ~~~~
```

(It's the end of the day so I pasted the above error message the hardest way I could think of: by typing it out instead of copying and pasting. Please disregard any typos except insofar as they reflect negatively on my intelligence.)

Python 2's module init function is void so cannot return even `NULL` whereas Python 3's must return a pointer (apparently).
