### PR TITLE
add_clauses: support array.array as input

### DIFF
--- a/pycosat.c
+++ b/pycosat.c
@@ -227,12 +227,17 @@ static int _check_array_typecode(PyObject *clauses) {
                         "invalid clause array: typecode is NULL");
         return -1;
     }
+#ifdef IS_PY3K
     typecode_bytes = PyUnicode_AsASCIIString(py_typecode);
+    Py_DECREF(py_typecode);
     if (typecode_bytes == NULL) {
         PyErr_SetString(PyExc_ValueError,
                         "invalid clause array: could not get typecode bytes");
         return -1;
     }
+#else
+    typecode_bytes = py_typecode;
+#endif
     typecode_cstr = PyBytes_AsString(typecode_bytes);
     if (typecode_cstr == NULL) {
         Py_DECREF(typecode_bytes);
@@ -246,11 +251,9 @@ static int _check_array_typecode(PyObject *clauses) {
                      "invalid clause array: invalid typecode '%s'",
                      typecode_cstr);
         Py_DECREF(typecode_bytes);
-        Py_DECREF(py_typecode);
         return -1;
     }
     Py_DECREF(typecode_bytes);
-    Py_DECREF(py_typecode);
     if (typecode != 'i' && typecode != 'l' && typecode != 'q') {
         PyErr_Format(PyExc_ValueError,
                      "invalid clause array: invalid typecode '%c'", typecode);


### PR DESCRIPTION
This is more or less the same as recently added to CryptoMiniSat:

@mbargull at https://github.com/msoos/cryptominisat/pull/519#issue-210978943:
> Adds support to the `add_clauses` method of the Python interface for passing over clauses as a flat `array.array` of integers. Each clause has to be terminated by a zero, such that the integer array represents a stream of zero separated clauses.
> 
> In a subsequent step, this could be improved upon to support not only `array.array` instances but additionally support the [Python C-API buffer protocol](https://docs.python.org/3/c-api/buffer.html). If anyone with more experience around the Python C-API wants to volunteer for it, this would be highly appreciated!

refs:
https://github.com/msoos/cryptominisat/pull/515
https://github.com/msoos/cryptominisat/pull/519
https://github.com/msoos/cryptominisat/pull/520
https://github.com/conda/conda/pull/7676
https://github.com/conda/conda/pull/7676#issuecomment-414338896
https://github.com/conda/conda/issues/7697