### PR TITLE
Add Negative Phase Search Option

### DIFF
--- a/picosat.c
+++ b/picosat.c
@@ -525,6 +525,7 @@ struct PicoSAT
   FILE *out;
   char * prefix;
   int verbosity;
+  int minimallity;
   int plain;
   unsigned LEVEL;
   unsigned max_var;
@@ -6773,6 +6774,13 @@ picosat_set_verbosity (PS * ps, int new_verbosity_level)
 {
   check_ready (ps);
   ps->verbosity = new_verbosity_level;
+}
+
+void
+picosat_set_minimallity (PS * ps, int new_minimallity_level)
+{
+  check_ready (ps);
+  ps->minimallity = new_minimallity_level;
 }
 
 void

--- a/picosat.h
+++ b/picosat.h
@@ -111,6 +111,12 @@ void picosat_set_prefix (PicoSAT *, const char *);
  */
 void picosat_set_verbosity (PicoSAT *, int new_verbosity_level);
 
+/* Set minimallity level.  A minimallity level of 1 
+Means that non minimal solutions will be skipped.
+There is no guarantee that all solutions returned are minimal
+ */
+void picosat_set_minimallity (PicoSAT *, int new_minimallity_level);
+
 /* Disable/Enable all pre-processing, currently only failed literal probing.
  *
  *  new_plain_value != 0    only 'plain' solving, so no preprocessing


### PR DESCRIPTION
This MR adds a `minimal` keyword argument, which optimizes PicoSat for finding minimal solutions

# Motivation
In many practical applications the literals are control flags. Due to the risk of unforeseen consequences in the presence of unnecessary changes, it is beneficial to minimize them.

# Changes
- Adds a minimal keyword argument which defaults to False
- When `minimal=False` the code runs exactly as before.
- When `minimal=True`:
    - The default Phase is Negative instead of using the Jeruslow-Wang heuristic
    - When a solution is found, instead of adding the inverse of the current solution, it adds the inverse of an And join of the literals set with their Phase to true. This means that all solutions which are strictly larger than this one, in the superset sense, will not be returned, keeping to the idea of returning minimal solutions only.

# Usage example
```python
import pycosat
g = pycosat.itersolve([[2*i,2*i+1] for i in range(1,1000)], minimal=True)
next(g)
```

This imediately returns a solution with only 500 positive values, which is the least number needed for it to be true. The current implementation returns all variables set to True (i.e. all positive)