### PR TITLE
use PyMem_Calloc() to initialize memory

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Next:
 -----
   * Update Python version support
+  * Use PyMem_Calloc() to initialize memory to 0.
 
 2022-10-24   0.6.4:
 -------------------

--- a/pycosat.c
+++ b/pycosat.c
@@ -5,7 +5,7 @@
   uses an MIT style license.
 */
 #define PYCOSAT_URL  "https://pypi.python.org/pypi/pycosat"
-#define PYCOSAT_VERSION  "0.6.4"
+#define PYCOSAT_VERSION  "0.6.5"
 
 #include <Python.h>
 
@@ -271,7 +271,7 @@ static PyObject* itersolve(PyObject *self, PyObject *args, PyObject *kwds)
     if (it->picosat == NULL)
         return NULL;
 
-    it->mem = PyMem_Malloc(picosat_variables(it->picosat) + 1);
+    it->mem = PyMem_Calloc(picosat_variables(it->picosat) + 1);
     if (it->mem == NULL) {
         PyErr_NoMemory();
         return NULL;


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

I noticed we don't initialize or access the 0'th byte of this array, unlike in https://github.com/zimmski/picosat/blob/master/app.c#L233. Instead, use `PyMem_Calloc()`