### PR TITLE
Fix tests on Python 3.13

### DIFF
--- a/news/101-fix-tests-python-3.13
+++ b/news/101-fix-tests-python-3.13
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Fix tests on Python 3.13 by replacing `unittest.makeSuite` with `unittest.defaultTestLoader.loadTestsFromTestCase`.
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,8 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Topic :: Utilities",
     ],
     ext_modules=[Extension(**ext_kwds)],

--- a/test_pycosat.py
+++ b/test_pycosat.py
@@ -258,7 +258,7 @@ def run(verbosity=1, repeat=1):
     suite = unittest.TestSuite()
     for cls in tests:
         for _ in range(repeat):
-            suite.addTest(unittest.makeSuite(cls))
+            suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(cls))
 
     runner = unittest.TextTestRunner(verbosity=verbosity)
     return runner.run(suite)


### PR DESCRIPTION
### Description

Closes #100.

Tests fail on Python 3.13 because of a function `unittest.makeSuite` that was deprecated in Python 3.11 and removed in Python 3.13.

This PR applies the patch proposed in #100 to fix the problem. The new code is backwards-compatible as far as Python 2.7, so there is no concern about regression for older Python versions.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/pycosat/blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?
